### PR TITLE
fix(core,language): avoid using path aliases

### DIFF
--- a/packages/core-kit/src/language.ts
+++ b/packages/core-kit/src/language.ts
@@ -1,7 +1,7 @@
 import { LanguageTag, languageTagGuard } from '@logto/language-kit';
 import { z } from 'zod';
 
-import { fallback } from '@/utilities';
+import { fallback } from './utilities';
 
 export const getDefaultLanguageTag = (language: string): LanguageTag =>
   languageTagGuard.or(fallback<LanguageTag>('en')).parse(language);

--- a/packages/core-kit/tsconfig.json
+++ b/packages/core-kit/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "@silverhand/ts-config/tsconfig.base",
   "compilerOptions": {
     "outDir": "lib",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "baseUrl": "."
   },
   "include": ["src", "declaration", "jest.config.ts"]
 }

--- a/packages/language-kit/tsconfig.json
+++ b/packages/language-kit/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "@silverhand/ts-config/tsconfig.base",
   "compilerOptions": {
     "outDir": "lib",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "baseUrl": "."
   },
   "include": ["src", "jest.config.ts"]
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Avoid using [`tsconfig.paths`](https://www.typescriptlang.org/tsconfig/#paths) (path aliases).

---

Background:

- Use `tsc` to build `core-kit` with [`tsconfig.paths`](https://www.typescriptlang.org/tsconfig/#paths) config (path aliases), but

    > `tsc` does not convert or map the paths alias for you.

    Reference: [Setting up Path Alias in TypeScript and tsc build without error](https://medium.com/@jimcraft123hd/setting-up-path-alias-in-typescript-and-tsc-build-without-error-9f1dbc0bccd2)

- When logto/logto imported package `core-kit`, build failed:

    <img width="1155" alt="image" src="https://user-images.githubusercontent.com/10594507/192676365-2ecf3ea9-d3bc-463c-bf5a-90c6406b17c5.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested.
