### PR TITLE
fix: make standard connectors display name configurable

### DIFF
--- a/packages/connector-kit/src/types.ts
+++ b/packages/connector-kit/src/types.ts
@@ -93,6 +93,7 @@ const connectorMetadataGuard = z.object({
 export const configurableConnectorMetadataGuard = connectorMetadataGuard
   .pick({
     target: true,
+    name: true,
     logo: true,
     logoDark: true,
   })


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
make standard connectors display name configurable

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

